### PR TITLE
Fixing a spelling error in base plan rego file

### DIFF
--- a/lib/plan/base_tfplan.rego
+++ b/lib/plan/base_tfplan.rego
@@ -6,7 +6,7 @@ import data as tfplan
 variables = vars{
     some k
     vars := { k : v |
-        v := tfplan.varibales[k].value
+        v := tfplan.variables[k].value
         true
     }
 }


### PR DESCRIPTION
Signed-off-by: Ansu Varghese <avarghese@us.ibm.com>

@Anil-CM @paul-manish This fixes a small typo in the base policy file. 

The error was detected by using OPA's *new* type checking with schema feature that Mandana and I presented to you a few weeks ago. We ran `opa eval data.ibmcloud.tfplan.variables -d base_tfplan.rego -d tfplan.json` and saw that [variables](https://github.com/aavarghese/terraform-opa-ibm/blob/master/lib/plan/base_tfplan.rego#L6) was listing an empty set, even though my [tfplan](https://github.ibm.com/hrl-cicd-security/terraform-ca/blob/master/examples/terraform-provider-ibm-examples/cis-load-balancer_ok/variables.tf) file (converted to json for opa eval) has a list of variables. 

But, when a JSON schema for the tfplan file is provided via `opa eval data.ibmcloud.tfplan.variables -d base_tfplan.rego -d tfplan.json -s tfplan-schema.json` and a rule annotation added to the rego file, OPA informs us that there is a rego type error with the following compile-time error:
```
"errors": [
    {
      "message": "undefined ref: data.varibales[k].value",
      "code": "rego_type_error",
      "location": {
        "file": "/Users/ansuvarghese/go/src/github.com/opa-schema-examples/cra/base_tfplan.rego",
        "row": 10,
        "col": 14
      },
      "details": {
        "ref": [
          {
            "type": "var",
            "value": "data"
          },
          {
            "type": "string",
            "value": "varibales"
          },
          {
            "type": "var",
            "value": "k"
          },
          {
            "type": "string",
            "value": "value"
          }
        ],
        "pos": 1,
        "want": {
          "type": "string"
        },
        "oneOf": [
          "configuration",
          "format_version",
          "output_changes",
          "planned_values",
          "prior_state",
          "resource_changes",
          "terraform_version",
          "variables"
        ]
      }
```


References: https://github.com/open-policy-agent/opa/pull/3060, and https://github.com/open-policy-agent/opa/pull/3123
cc: @vazirim @fadycopty @jrdoran @nadgowdas 